### PR TITLE
feat: add plugin support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Gezondheid `/ɣəˈzɔntˌɦɛi̯t/` (Dutch for "Health") is a simple CLI tool t
 
 ## Plugins
 
-Behaviour can be extanded with 3th party plugins like [gezonheid-hook](https://github.com/LiamEderzeel/gezondheid-hook) to add webhook support when healthchecks fail.
+Behaviour can be extended with 3rd party plugins like [gezondheid-hook](https://github.com/LiamEderzeel/gezondheid-hook) to add webhook support when health checks fail.
 
 ```yaml
 - name: test.test

--- a/README.md
+++ b/README.md
@@ -6,3 +6,23 @@
 Gezondheid `/ɣəˈzɔntˌɦɛi̯t/` (Dutch for "Health") is a simple CLI tool to periodically check the health of URLs.
 
 👷‍♂️ This project (and readme) is under construction
+
+## Plugins
+
+Behaviour can be extanded with 3th party plugins like [gezonheid-hook](https://github.com/LiamEderzeel/gezondheid-hook) to add webhook support when healthchecks fail.
+
+```yaml
+- name: test.test
+  url: https://test.test
+  interval: 10s
+  plugins:
+    - name: "gezondheid-hook.so"
+      config:
+        method: "POST"
+        url: "https://webhook.test"
+        statusCodeMinimum: 200
+```
+
+
+
+

--- a/cmd/monitor.go
+++ b/cmd/monitor.go
@@ -96,7 +96,7 @@ func monitor(client *http.Client, config RemoteConfig) {
 		p := plugins.LoadPlugin(ps.Name)
 		ymlData, err := json.Marshal(ps.Config)
 		if err != nil {
-			log.Fatalf("Failed to create request for #%v!\n", config.Url)
+			log.Fatalf("Failed to create request for %#v!\n", config.Url)
 		}
 
 		p.SetConfig(ymlData)

--- a/cmd/monitor.go
+++ b/cmd/monitor.go
@@ -107,7 +107,7 @@ func monitor(client *http.Client, config RemoteConfig) {
 	h := &DefaultHandler{req: req, duration: duration, client: client, config: config}
 	hs = append(hs, h)
 
-	var first = handlers.SetNextRefrences(hs)
+	var first = handlers.SetNextReferences(hs)
 
 	for {
 		first.HandleRequest(&handlers.Ctx{})

--- a/cmd/monitor.go
+++ b/cmd/monitor.go
@@ -4,12 +4,14 @@ Copyright © 2023 NAME HERE <EMAIL ADDRESS>
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
+	"github.com/bobbiegoede/gezondheid/internal/handlers"
+	"github.com/bobbiegoede/gezondheid/internal/plugins"
+	"github.com/spf13/cobra"
 	"log"
 	"net/http"
 	"time"
-
-	"github.com/spf13/cobra"
 )
 
 // monitorCmd represents the monitor command
@@ -52,6 +54,31 @@ to quickly create a Cobra application.`,
 	},
 }
 
+type DefaultHandler struct {
+	config   RemoteConfig
+	client   *http.Client
+	req      *http.Request
+	duration time.Duration
+	next     handlers.Handler
+}
+
+func (h *DefaultHandler) HandleRequest(ctx *handlers.Ctx) {
+	res, err := h.client.Do(h.req)
+	if err != nil {
+		log.Fatalf("Received error: %v\n", err.Error())
+	}
+
+	ctx.Proto = res.Proto
+	ctx.StatusCode = res.StatusCode
+
+	// if res.StatusCode >= 300 {
+	fmt.Printf("%-40s%v\n", h.config.Url, res.Status)
+}
+
+func (h *DefaultHandler) SetNext(handler handlers.Handler) {
+	h.next = handler
+}
+
 func monitor(client *http.Client, config RemoteConfig) {
 	duration, err := time.ParseDuration(config.Interval)
 	if err != nil {
@@ -63,15 +90,27 @@ func monitor(client *http.Client, config RemoteConfig) {
 		log.Fatalf("Failed to create request for #%v!\n", config.Url)
 	}
 
-	for {
-		res, err := client.Do(req)
+	var hs []handlers.Handler
+
+	for _, ps := range config.Plugins {
+		p := plugins.LoadPlugin(ps.Name)
+		ymlData, err := json.Marshal(ps.Config)
 		if err != nil {
-			log.Fatalf("Received error: %v\n", err.Error())
+			log.Fatalf("Failed to create request for #%v!\n", config.Url)
 		}
 
-		// if res.StatusCode >= 300 {
-		fmt.Printf("%-40s%v\n", config.Url, res.Status)
-		// }
+		p.SetConfig(ymlData)
+		h := &plugins.PluginHandler{Plugin: p}
+		hs = append(hs, h)
+	}
+
+	h := &DefaultHandler{req: req, duration: duration, client: client, config: config}
+	hs = append(hs, h)
+
+	var first = handlers.SetNextRefrences(hs)
+
+	for {
+		first.HandleRequest(&handlers.Ctx{})
 		time.Sleep(duration)
 	}
 }

--- a/cmd/remote_config.go
+++ b/cmd/remote_config.go
@@ -11,10 +11,16 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+type Plugin struct {
+	Name   string         `json:"name"`
+	Config map[string]any `json:"config"`
+}
+
 type RemoteConfig struct {
-	Name     string `json:"name"`
-	Url      string `json:"url"`
-	Interval string `json:"interval"`
+	Name     string   `json:"name"`
+	Url      string   `json:"url"`
+	Interval string   `json:"interval"`
+	Plugins  []Plugin `json:"plugins"`
 }
 type RemoteConfigs []RemoteConfig
 

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -1,0 +1,19 @@
+package handlers
+
+type Ctx struct {
+	Proto      string `json:"proto"`
+	StatusCode int    `json:"status"`
+}
+
+type Handler interface {
+	HandleRequest(ctx *Ctx)
+	SetNext(handler Handler)
+}
+
+func SetNextRefrences(hs []Handler) Handler {
+	for i := 0; i < len(hs)-1; i++ {
+		hs[i].SetNext(hs[i+1])
+	}
+
+	return hs[0]
+}

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -10,7 +10,7 @@ type Handler interface {
 	SetNext(handler Handler)
 }
 
-func SetNextRefrences(hs []Handler) Handler {
+func SetNextReferences(hs []Handler) Handler {
 	for i := 0; i < len(hs)-1; i++ {
 		hs[i].SetNext(hs[i+1])
 	}

--- a/internal/plugins/plugins.go
+++ b/internal/plugins/plugins.go
@@ -8,7 +8,7 @@ import (
 )
 
 type Plugin interface {
-	Run(getCotext func() []byte, next func())
+	Run(getContext func() []byte, next func())
 	SetConfig(config []byte)
 }
 
@@ -23,12 +23,12 @@ func LoadPlugin(path string) Plugin {
 		log.Fatalf("Error looking up symbol:\n%v", err)
 	}
 
-	middlware, ok := sym.(Plugin)
+	middleware, ok := sym.(Plugin)
 	if !ok {
 		log.Fatalf("Invalid plugin type:\n%v", err)
 	}
 
-	return middlware
+	return middleware
 }
 
 type PluginHandler struct {

--- a/internal/plugins/plugins.go
+++ b/internal/plugins/plugins.go
@@ -1,0 +1,55 @@
+package plugins
+
+import (
+	"encoding/json"
+	"github.com/bobbiegoede/gezondheid/internal/handlers"
+	"log"
+	"plugin"
+)
+
+type Plugin interface {
+	Run(getCotext func() []byte, next func())
+	SetConfig(config []byte)
+}
+
+func LoadPlugin(path string) Plugin {
+	plugin, err := plugin.Open(path)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	sym, err := plugin.Lookup("Plugin")
+	if err != nil {
+		log.Fatalf("Error looking up symbol:\n%v", err)
+	}
+
+	middlware, ok := sym.(Plugin)
+	if !ok {
+		log.Fatalf("Invalid plugin type:\n%v", err)
+	}
+
+	return middlware
+}
+
+type PluginHandler struct {
+	Plugin Plugin
+	next   handlers.Handler
+}
+
+func (h *PluginHandler) HandleRequest(ctx *handlers.Ctx) {
+	h.Plugin.Run(func() []byte {
+		jsonData, err := json.Marshal(ctx)
+		if err != nil {
+			log.Fatalf("Error serializing the struct:\n%v", err)
+		}
+		return jsonData
+	}, func() {
+		if h.next != nil {
+			h.next.HandleRequest(ctx)
+		}
+	})
+}
+
+func (h *PluginHandler) SetNext(handler handlers.Handler) {
+	h.next = handler
+}


### PR DESCRIPTION
Add support for runtime plugins that wrap the default health check request. A use case could be triggering a web-hook when the health-check fails. The following plugins acts as a [proof of concept plugin](https://github.com/LiamEderzeel/gezondheid-hook)

Plugins can be added and configured as follows: 

```
- name: test.test
  url: https://test.test
  interval: 10s
  plugins:
    - name: "/<path-to-shared-binary->/gezondheid-hook.so"
      config:
        method: "POST"
        url: "https://webhook.test"
        statusCodeMinimum: 200
```
The monitoring logic is now a wrapped in a handler witch can be chained, the logic is loosely based on [Koajs middlewares](https://github.com/koajs/koa/blob/master/docs/guide.md#writing-middleware). Handlers have a context to pass data and a `next()` to run the downstream handlers.

Plugins are wrapped by the Plugin Handler which loads the plugin from a go shared binary and passes the context and next function to the plugin.

the [go-plugins](https://pkg.go.dev/plugin) package has some short comings. And ideally we explore a different method for including plugins in the future in a later version. 
